### PR TITLE
Deploy script puts todo app in an appropriate directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ before_script:
 after_script:
   - npm test
 after_success:
-  - 'test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && bash deploy.sh'
+  - 'test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && bash deploy-ghpages.sh'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 0.10.33
+  - 0.12
 env:
   global:
     - GH_REF: github.com/vronvali/mytodo-gulp.git
@@ -9,9 +9,8 @@ before_script:
   - export CHROME_BIN=chromium-browser
   - 'export DISPLAY=:99.0'
   - sh -e /etc/init.d/xvfb start
-  - npm install -g bower karma grunt-cli jshint
-  - npm install
-  - bower install
+  - npm install -g bower 
+  - npm install -g gulp 
 after_script:
   - npm test
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,5 @@ before_script:
   - export CHROME_BIN=chromium-browser
   - 'export DISPLAY=:99.0'
   - sh -e /etc/init.d/xvfb start
-after_script:
-  - npm test
 after_success:
   - 'test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && bash deploy-ghpages.sh'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ env:
   global:
     - GH_REF: github.com/vronvali/mytodo-gulp.git
     - secure: neunZFaBP3cEgEltMWSMmT9VJB3vhAIE1hZfehZoyHnsM1xGrMHp4P9rH/d/BJYo+umn4vjDJ82cfdThFzgyi0K5qT7L7Hkj/YhHvYCzCiVun1HOPVhEqPm8T88AsqJdyF+Eld28hGKG/FRNyYGsn81J0UAS4d+lfDRdxprEX9quif9NKIbYsCh6SGVfkBzYo94fBf7Lky3Vje0dRIXfH47kz0w6d1mYmFYGsYtRIkX3OINI1RT5ctPkT7FT6A+QD6ZO0tncpQuqg0SfPcKnq43s09inlx8zW87prGbHWCCt4TVCHABbm3QUsOXuS48b1wsVaII9JKrNWRSJClfRzTdtUtlcds0nN+iOgTAQmpwrSpOhS1W4/Nbmy3SyY6cpjq7IsogJhNShwNb9FipP/4KY0hXh1DDcSxQDnbExu/5vsvAeD/fMANWebq3vCnRtl6+PdftrdMvOpFqZoRiIxAzRJMeNx6yr3cX7mZ8zfLTDWbQSz2g6/lBX4qvtvXg7OhCUoeKcvP+cycDOJZDI7ePvhYwdbC1D9syr6wwT4lhzIQpmgtSGg7GslX3L1IsRtLnXJi/F4dXJsCBy1qgBjMBvhgWrZ2hhYhqZpOllV9bWOxjmaF7iN3kgzRE0dbwQFy1rJ3l7hjK88sQuHPPglYk6LcEOlAj9UGdkehtnm/M=
+before_install:
+  - npm install -g bower karma gulp
 before_script:
   - export CHROME_BIN=chromium-browser
   - 'export DISPLAY=:99.0'
   - sh -e /etc/init.d/xvfb start
-  - npm install -g bower 
-  - npm install -g gulp 
 after_script:
   - npm test
 after_success:

--- a/deploy-ghpages.sh
+++ b/deploy-ghpages.sh
@@ -1,20 +1,31 @@
 #!/bin/bash
 
+echo "Building the app"
+gulp || exit 8;
+echo "Making sure the dist minified version of the app is ready"
+ls dist || exit 9;
+
 set -o errexit -o nounset
 
 rev=$(git rev-parse --short HEAD)
 
+echo "Ensuring Travis' commits are associated to him"
 git config user.name "Travis"
 git config user.email "vronvali@cesine.ca"
-git remote rm mywebsite
+
+echo "Ensuring Travis' has my website as a remote"
 git remote add mywebsite "https://$GH_TOKEN@github.com/vronvali/vronvali.github.io.git"
 git fetch mywebsite
-git branch -u mywebsite/gh-pages gh-pages
+git checkout -b gh-pages mywebsite/master
+git checkout gh-pages
 
-echo "vronvali.com" > CNAME
+echo "Moving todo app into the right directory for where it belongs on my website"
+mkdir -p apps
+mv dist apps/todos
 
-gulp
+echo "Committing the updated changes to the todo app"
+git add -A apps/todos
+git commit -m "rebuild todo App vronvali/mytodo-gulp at ${rev}"
 
-git add -A dist
-git commit -m "rebuild todoApp at ${rev}"
-git push -q mywebsite HEAD:gh-pages
+echo "Pushing the changes to my website on github (-q so that nothing gets printed in the travis logs which is sensitive)"
+git push -q mywebsite HEAD:master

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "dependencies": {},
   "scripts": {
     "test": "gulp test",
-    "deploy": "./deploy-ghpages.sh"
+    "deploy": "./deploy-ghpages.sh",
+    "postinstall": "bower install"
   },
   "devDependencies": {
     "browser-sync": "~2.7.12",

--- a/src/app/components/tutorial/tutorial.directive.js
+++ b/src/app/components/tutorial/tutorial.directive.js
@@ -8,7 +8,7 @@
  */
 angular.module("mytodo").directive("tutorialSlider", function() {
   return {
-    templateUrl: "components/tutorial/tutorial.html",
+    templateUrl: "app/components/tutorial/tutorial.html",
     restrict: "A",
     transclude: false,
     scope: {


### PR DESCRIPTION
I tested the deploy script and 
- modified it for your case where you need to push to a master of another remote, and
- I also moved the todo app into a directory called apps so that your website structure stays clean (rather than leaving it called dist)

After you merge this pull request you still wont see the new todo app in your website because there are minimally two more things to do:
- [ ] you need to re-generate your travis encrypted token to use the remote that you want to push to (vronvali/vronvali.github.io instead of vronvali/mytodo-gulp)
- [ ] you need to link the todo app in your website  (like you did for your game https://github.com/vronvali/vronvali.github.io/blob/master/index.html#L31)
- [ ] you have to fix the test that is broken (expect "hello hello" to equal "hello")(run `gulp test` to see the problem, and you can also see it when travis runs https://travis-ci.org/vronvali/mytodo-gulp#L853) but also
- [x] you should make an issue for https://github.com/Swiip/generator-gulp-angular saying that their gulp doesn't actually produce an error when the test fail! show them this build https://travis-ci.org/vronvali/mytodo-gulp/builds/69766141 it shows that travis thinks that gulp test was successful when it wasn't. then you should try to fix this problem for them by figuring out what is missing using your project, and then modifying their template files https://github.com/Swiip/generator-gulp-angular/tree/master/app/templates to do this
